### PR TITLE
MAP and SPI updates

### DIFF
--- a/MAP/v_MAP$CDF#identifiers.sql
+++ b/MAP/v_MAP$CDF#identifiers.sql
@@ -38,6 +38,17 @@ SELECT co.schoolid
                             END, 0)
         ELSE NULL
        END AS proj_ACT_subj_score
+      ,CASE
+        /* MATH ACT model */
+        WHEN sub.measurementscale = 'Mathematics'
+             THEN ROUND(
+               -28.193 + (0.307 * sub.testritscore) + ((-4.256 * 11) + (0.183 * (11 * 11))) + -2.346, 0)
+        /* READING ACT model */
+        WHEN sub.measurementscale = 'Reading'
+             THEN ROUND(
+              -52.748 + (0.417 * sub.testritscore) + ((-3.433 * 11) + (0.132 * (11 * 11))) + -1.655, 0)
+        ELSE NULL
+       END AS proj_ACT_subj_today
       ,ROW_NUMBER() OVER(
          PARTITION BY sub.student_number, sub.academic_year, sub.measurementscale
            ORDER BY sub.rn ASC, sub.teststartdate ASC, sub.teststarttime ASC) AS rn_base

--- a/MAP/v_MAP$norm_table_extended#2015#dense.sql
+++ b/MAP/v_MAP$norm_table_extended#2015#dense.sql
@@ -1,0 +1,70 @@
+USE [KIPP_NJ]
+GO
+
+CREATE VIEW MAP$norm_table_extended#2015#dense AS
+
+WITH nums AS (
+  SELECT n
+  FROM KIPP_NJ..UTIL$row_generator WITH (NOLOCK)
+  WHERE n BETWEEN 0 AND 100
+ )
+,base_norms AS (
+  SELECT n.measurementscale
+        ,n.fallwinterspring
+        ,n.grade
+        ,n.RIT
+        ,n.student_percentile
+         --partition to get only one row per percentile
+         --later we'll union to put humpty dumpty back together
+        ,ROW_NUMBER() OVER(
+           PARTITION BY n.measurementscale, n.fallwinterspring, n.grade, n.student_percentile
+               ORDER BY RIT DESC) AS rn
+  FROM KIPP_NJ..MAP$norm_table_extended#2015 n WITH (NOLOCK)
+  WHERE n.student_percentile <= 50
+  
+  UNION 
+  
+  SELECT n.measurementscale
+        ,n.fallwinterspring
+        ,n.grade
+        ,n.RIT
+        ,n.student_percentile
+        ,ROW_NUMBER() OVER(
+           PARTITION BY n.measurementscale, n.fallwinterspring, n.grade, n.student_percentile
+             ORDER BY RIT ASC) AS rn
+  FROM KIPP_NJ..MAP$norm_table_extended#2015 n WITH (NOLOCK)
+  WHERE n.student_percentile > 50
+ )
+
+SELECT sub.measurementscale
+      ,sub.fallwinterspring
+      ,sub.grade
+      ,sub.RIT
+      ,sub.student_percentile
+FROM
+    (
+     SELECT base_norms.measurementscale
+           ,base_norms.fallwinterspring
+           ,base_norms.grade
+           ,base_norms.RIT
+           ,nums.n AS student_percentile
+           ,ROW_NUMBER() OVER(
+              PARTITION BY base_norms.measurementscale, base_norms.fallwinterspring, base_norms.grade, nums.n
+                ORDER BY ABS(base_norms.student_percentile - nums.n)) AS rn
+     FROM nums WITH(NOLOCK)
+     JOIN base_norms WITH(NOLOCK)
+       ON base_norms.rn = 1
+     ) sub
+WHERE sub.rn = 1
+
+UNION 
+
+SELECT base_norms.measurementscale
+      ,base_norms.fallwinterspring
+      ,base_norms.grade
+      ,base_norms.RIT
+      ,base_norms.student_percentile
+FROM base_norms
+GO
+
+

--- a/MAP/v_MAP$norm_table_extended#2015.sql
+++ b/MAP/v_MAP$norm_table_extended#2015.sql
@@ -1,0 +1,106 @@
+USE [KIPP_NJ]
+GO
+
+CREATE VIEW MAP$norm_table_extended#2015 AS
+
+WITH master_norms AS (
+  SELECT measurementscale,
+         fallwinterspring, 
+         grade,
+         RIT,
+         student_percentile
+  FROM KIPP_NJ..MAP$norm_table#2015 WITH(NOLOCK)
+ )
+/*
+--what is missing
+SELECT DISTINCT measurementscale, grade
+FROM master_norms
+ORDER BY measurementscale, grade ASC
+*/
+--regular norm table
+SELECT *
+FROM master_norms
+
+UNION ALL
+
+--not covered areas:
+--reading 12
+SELECT measurementscale
+      ,fallwinterspring
+      ,12 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'Reading'
+  AND grade = 11
+
+UNION ALL
+
+--math 12
+SELECT measurementscale
+      ,fallwinterspring
+      ,12 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'Mathematics'
+  AND grade = 11
+
+UNION ALL
+
+--language 12
+SELECT measurementscale
+      ,fallwinterspring
+      ,12 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'Language Usage'
+  AND grade = 11
+
+UNION ALL
+
+--general science 9, 10, 11, 12
+SELECT measurementscale
+      ,fallwinterspring
+      ,9 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'General Science'
+  AND grade = 8
+
+UNION ALL
+
+SELECT measurementscale
+      ,fallwinterspring
+      ,10 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'General Science'
+  AND grade = 8
+
+UNION ALL
+
+SELECT measurementscale
+      ,fallwinterspring
+      ,11 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'General Science'
+  AND grade = 8
+
+UNION ALL
+
+SELECT measurementscale
+      ,fallwinterspring
+      ,12 AS grade
+      ,RIT
+      ,student_percentile
+FROM master_norms
+WHERE measurementscale = 'General Science'
+  AND grade = 8
+
+

--- a/SPI/v_SPI$walkthrough_scale_avg.sql
+++ b/SPI/v_SPI$walkthrough_scale_avg.sql
@@ -4,7 +4,7 @@ GO
 ALTER VIEW SPI$walkthrough_scale_avg AS
 
 WITH prep AS (
-  SELECT r.rubric
+  SELECT DISTINCT r.rubric
         ,r.element
         ,r.school
         ,r.round
@@ -19,7 +19,8 @@ WITH prep AS (
           WHEN ISNULL(r.num_yes, 0.0) + ISNULL(r.num_no, 0.0) = 0.0 THEN 0.0
           WHEN (r.num_yes IS NOT NULL OR r.num_no IS NOT NULL) THEN CAST(r.num_yes / (r.num_yes + r.num_no) AS NUMERIC(4,2)) * 10
          END AS use_this
-  FROM SPI..walkthrough$raw_long r WITH(NOLOCK)
+  FROM SPI..walkthrough$raw_long r WITH (NOLOCK)
+  WHERE r.date >= '09-01-2015'
  )
 
 SELECT prep.school


### PR DESCRIPTION
@cbini for review -- 3 changes here;

1) added the 2015 student norms to the database, and the corresponding 'dense' views (one row per percentile/subject/grade/season)

2) modified the main MAP view so that it shows the _current_ ACT equivalency, as well as the 11th grade on-track equivalency

3) SPI update for 2015 (new scale conversion for new rubric).

Let me know if you have any questions about any of these!  
